### PR TITLE
Title:  Fix - Correct typo in VMware

### DIFF
--- a/go/backend/routes/factory.go
+++ b/go/backend/routes/factory.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/backend/routes/findings.go
+++ b/go/backend/routes/findings.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/backend/routes/rules.go
+++ b/go/backend/routes/rules.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/backend/routes/rules_routes_test.go
+++ b/go/backend/routes/rules_routes_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/backend/routes/runs.go
+++ b/go/backend/routes/runs.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/backend/routes/slocs.go
+++ b/go/backend/routes/slocs.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/backend/services/app.go
+++ b/go/backend/services/app.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/backend/services/data.go
+++ b/go/backend/services/data.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/backend/services/factory.go
+++ b/go/backend/services/factory.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/backend/services/portfolio.go
+++ b/go/backend/services/portfolio.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/backend/services/scoring.go
+++ b/go/backend/services/scoring.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/csa.go
+++ b/go/csa.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 
@@ -83,7 +83,7 @@ func main() {
 
 	util.App.HelpFlag.Short('?')
 	util.App.Version(Version)
-	util.App.Author("Steve Woods (VMWare)")
+	util.App.Author("Steve Woods (VMware)")
 
 	var run = model.NewRun()
 

--- a/go/csa/AppAnalyzer.go
+++ b/go/csa/AppAnalyzer.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/csa/CsaService.go
+++ b/go/csa/CsaService.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/csa/FileCollector.go
+++ b/go/csa/FileCollector.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/csa/FileProccesor.go
+++ b/go/csa/FileProccesor.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/csa/ScoreLevels.go
+++ b/go/csa/ScoreLevels.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/csa/ScoreLevels_test.go
+++ b/go/csa/ScoreLevels_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/Bin_Repository.go
+++ b/go/db/Bin_Repository.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/CollectedData.go
+++ b/go/db/CollectedData.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/DbMain.go
+++ b/go/db/DbMain.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/ReferenceData.go
+++ b/go/db/ReferenceData.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/Rules.go
+++ b/go/db/Rules.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/Scoring_Repository.go
+++ b/go/db/Scoring_Repository.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/bin_repository_test.go
+++ b/go/db/bin_repository_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/finding_repository.go
+++ b/go/db/finding_repository.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/finding_repository_test.go
+++ b/go/db/finding_repository_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/reportdata_repository.go
+++ b/go/db/reportdata_repository.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/reportdata_repository_test.go
+++ b/go/db/reportdata_repository_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/rule_repositories_test.go
+++ b/go/db/rule_repositories_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/rule_repository.go
+++ b/go/db/rule_repository.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/rules_test.go
+++ b/go/db/rules_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/run_repository.go
+++ b/go/db/run_repository.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/run_repository_test.go
+++ b/go/db/run_repository_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/sloc_repository.go
+++ b/go/db/sloc_repository.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/sloc_repository_test.go
+++ b/go/db/sloc_repository_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/db/test_support/utils.go
+++ b/go/db/test_support/utils.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/frontend/python/setup-dev.py
+++ b/go/frontend/python/setup-dev.py
@@ -10,7 +10,7 @@
 #  REQUIREMENTS:  ---
 #          BUGS:  ---
 #        AUTHOR:  App Tx Team (Steve Woods)
-#       COMPANY:  VMWare
+#       COMPANY:  VMware
 #       VERSION:  1.0
 #       CREATED:  08/26/2020
 #      REVISION:  1.0

--- a/go/frontend/rules-admin.go
+++ b/go/frontend/rules-admin.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package main

--- a/go/frontend/src/App.css
+++ b/go/frontend/src/App.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc.
+ * Copyright (c) 2018 - Present VMware, Inc.
  */
 
 .App {

--- a/go/frontend/src/App.js
+++ b/go/frontend/src/App.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/App.t_st.js
+++ b/go/frontend/src/App.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/application-view/ApplicationViewComponent.js
+++ b/go/frontend/src/application-view/ApplicationViewComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/application-view/ApplicationViewComponent.t_st.js
+++ b/go/frontend/src/application-view/ApplicationViewComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/application-view/ApplicationViewService.js
+++ b/go/frontend/src/application-view/ApplicationViewService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/DataViewComponent.js
+++ b/go/frontend/src/data-view/DataViewComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/DataViewComponent.t_st.js
+++ b/go/frontend/src/data-view/DataViewComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/DataViewService.js
+++ b/go/frontend/src/data-view/DataViewService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/annotations/AnnotationsComponent.js
+++ b/go/frontend/src/data-view/annotations/AnnotationsComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/annotations/AnnotationsComponent.t_st.js
+++ b/go/frontend/src/data-view/annotations/AnnotationsComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/api-by-app/ApiByAppComponent.js
+++ b/go/frontend/src/data-view/api-by-app/ApiByAppComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/api-by-app/ApiByAppComponent.t_st.js
+++ b/go/frontend/src/data-view/api-by-app/ApiByAppComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/api-usage-detailed/ApiUsageDetailedComponent.js
+++ b/go/frontend/src/data-view/api-usage-detailed/ApiUsageDetailedComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/api-usage-detailed/ApiUsageDetailedComponent.t_st.js
+++ b/go/frontend/src/data-view/api-usage-detailed/ApiUsageDetailedComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/api-usage-summary/ApiUsageSummaryComponent.js
+++ b/go/frontend/src/data-view/api-usage-summary/ApiUsageSummaryComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/api-usage-summary/ApiUsageSummaryComponent.t_st.js
+++ b/go/frontend/src/data-view/api-usage-summary/ApiUsageSummaryComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/findings-all/FindingsComponent.js
+++ b/go/frontend/src/data-view/findings-all/FindingsComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/findings-all/FindingsComponent.t_st.js
+++ b/go/frontend/src/data-view/findings-all/FindingsComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/rule-by-app/RuleByAppComponent.js
+++ b/go/frontend/src/data-view/rule-by-app/RuleByAppComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/rule-by-app/RuleByAppComponent.t_st.js
+++ b/go/frontend/src/data-view/rule-by-app/RuleByAppComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/rule-metrics/RuleMetricsComponent.js
+++ b/go/frontend/src/data-view/rule-metrics/RuleMetricsComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/rule-metrics/RuleMetricsComponent.t_st.js
+++ b/go/frontend/src/data-view/rule-metrics/RuleMetricsComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/search/SearchHtmlTableComponent.js
+++ b/go/frontend/src/data-view/search/SearchHtmlTableComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/search/SearchHtmlTableComponent.t_st.js
+++ b/go/frontend/src/data-view/search/SearchHtmlTableComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/source-code/SourceCodeComponent.js
+++ b/go/frontend/src/data-view/source-code/SourceCodeComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/source-code/SourceCodeComponent.t_st.js
+++ b/go/frontend/src/data-view/source-code/SourceCodeComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/third-party/ThirdPartyComponent.js
+++ b/go/frontend/src/data-view/third-party/ThirdPartyComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/data-view/third-party/ThirdPartyComponent.t_st.js
+++ b/go/frontend/src/data-view/third-party/ThirdPartyComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/executive-summary-view/AppRadarChart.js
+++ b/go/frontend/src/executive-summary-view/AppRadarChart.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/executive-summary-view/ExecutiveSummaryService.js
+++ b/go/frontend/src/executive-summary-view/ExecutiveSummaryService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/executive-summary-view/ExecutiveSummaryViewComponent.js
+++ b/go/frontend/src/executive-summary-view/ExecutiveSummaryViewComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/executive-summary-view/ExecutiveSummaryViewComponent.t_st.js
+++ b/go/frontend/src/executive-summary-view/ExecutiveSummaryViewComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/executive-summary-view/ReactVisChartComponent.js
+++ b/go/frontend/src/executive-summary-view/ReactVisChartComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/executive-summary-view/RecommendationBar.js
+++ b/go/frontend/src/executive-summary-view/RecommendationBar.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/executive-summary-view/RecommendationSunBurst.js
+++ b/go/frontend/src/executive-summary-view/RecommendationSunBurst.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/executive-summary-view/RecommendationTreeMap.js
+++ b/go/frontend/src/executive-summary-view/RecommendationTreeMap.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/index.css
+++ b/go/frontend/src/index.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare
+ * Copyright (c) 2018 - Present VMware
  */
 
 /*Set Background of Active Tab*/

--- a/go/frontend/src/index.js
+++ b/go/frontend/src/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/portfolio-view/PortfolioViewComponent.js
+++ b/go/frontend/src/portfolio-view/PortfolioViewComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/portfolio-view/PortfolioViewComponent.t_st.js
+++ b/go/frontend/src/portfolio-view/PortfolioViewComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/portfolio-view/PortfolioViewService.js
+++ b/go/frontend/src/portfolio-view/PortfolioViewService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/rules-view/RulesService.js
+++ b/go/frontend/src/rules-view/RulesService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/rules-view/RulesService.t_st.js
+++ b/go/frontend/src/rules-view/RulesService.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/rules-view/RulesTableComponent.js
+++ b/go/frontend/src/rules-view/RulesTableComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/rules-view/RulesTableComponent.t_st.js
+++ b/go/frontend/src/rules-view/RulesTableComponent.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/run-container/RunContainer.js
+++ b/go/frontend/src/run-container/RunContainer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 
@@ -331,7 +331,7 @@ export default class RunContainer extends Component {
             <div className="ui-g-1">
               <img
                 id="logo"
-                src="/VMWare-logo.svg"
+                src="/VMware-logo.svg"
                 width="60"
                 height="60"
                 alt="vmware-logo"

--- a/go/frontend/src/run-container/RunContainerService.js
+++ b/go/frontend/src/run-container/RunContainerService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/run-container/RunDetails.js
+++ b/go/frontend/src/run-container/RunDetails.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/setupTests.js
+++ b/go/frontend/src/setupTests.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/shared/DashboardCard.js
+++ b/go/frontend/src/shared/DashboardCard.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/shared/DashboardCard.t_st.js
+++ b/go/frontend/src/shared/DashboardCard.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/shared/ScoreCard.js
+++ b/go/frontend/src/shared/ScoreCard.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/shared/ScoreCard.t_st.js
+++ b/go/frontend/src/shared/ScoreCard.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/util/CustomTreeMapContent.js
+++ b/go/frontend/src/util/CustomTreeMapContent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/util/DropDownUtil.js
+++ b/go/frontend/src/util/DropDownUtil.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/util/DropDownUtil.t_st.js
+++ b/go/frontend/src/util/DropDownUtil.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/util/FindingDetails.js
+++ b/go/frontend/src/util/FindingDetails.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/util/KeyValuePairComponent.js
+++ b/go/frontend/src/util/KeyValuePairComponent.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/util/ListUtils.js
+++ b/go/frontend/src/util/ListUtils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/util/NavBarUtil.js
+++ b/go/frontend/src/util/NavBarUtil.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/util/NotificationUtil.js
+++ b/go/frontend/src/util/NotificationUtil.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/util/TreeMapUtil.js
+++ b/go/frontend/src/util/TreeMapUtil.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/util/TreeMapUtil.t_st.js
+++ b/go/frontend/src/util/TreeMapUtil.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/view-template/Footer.js
+++ b/go/frontend/src/view-template/Footer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 
@@ -18,7 +18,7 @@ target="_blank"
 href="https://vmware.com/"
 rel="noopener noreferrer"
     >
-    VMWare
+    VMware
 </a>, Inc.
 </p>
 </div>

--- a/go/frontend/src/view-template/Footer.t_st.js
+++ b/go/frontend/src/view-template/Footer.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/frontend/src/view-template/NavBar.js
+++ b/go/frontend/src/view-template/NavBar.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 
@@ -44,7 +44,7 @@ export const NavBar = () => (
     <Menubar model={items} style={{ border: 'none', background: '#edf0f5' }}>
       <img
         id="logo"
-        src="/VMWare-logo.svg"
+        src="/VMware-logo.svg"
         width="60"
         height="60"
         alt="vmware-logo"

--- a/go/frontend/src/view-template/NavBar.t_st.js
+++ b/go/frontend/src/view-template/NavBar.t_st.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  */
 

--- a/go/gocloc/cloc.go
+++ b/go/gocloc/cloc.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package gocloc

--- a/go/gocloc/file.go
+++ b/go/gocloc/file.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package gocloc

--- a/go/gocloc/file_test.go
+++ b/go/gocloc/file_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package gocloc

--- a/go/gocloc/gocloc.go
+++ b/go/gocloc/gocloc.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package gocloc

--- a/go/gocloc/language_test.go
+++ b/go/gocloc/language_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package gocloc

--- a/go/gocloc/utils.go
+++ b/go/gocloc/utils.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package gocloc

--- a/go/gocloc/utils_test.go
+++ b/go/gocloc/utils_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package gocloc

--- a/go/gocloc/xml.go
+++ b/go/gocloc/xml.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package gocloc

--- a/go/model-cache/Bootstrap.go
+++ b/go/model-cache/Bootstrap.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package model

--- a/go/model-cache/ScoringModelBootstrap.go
+++ b/go/model-cache/ScoringModelBootstrap.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package model

--- a/go/model/ApplicationConfig.go
+++ b/go/model/ApplicationConfig.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/Bin.go
+++ b/go/model/Bin.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/BinBootstrap.go
+++ b/go/model/BinBootstrap.go
@@ -5,7 +5,7 @@
 package model
 
 //Created By BootstrapBinsTemplate.txt found under go/resources folder
-//Created @ 2020-11-20 18:04:48.117364299 +0000 UTC m=+0.097369900
+//Created @ 2020-12-11 16:46:37.171324297 +0000 UTC m=+0.077850745
 
 func BootstrapBins() []Bin {
     var BootstrapBins = []Bin{

--- a/go/model/Bootstrap.go
+++ b/go/model/Bootstrap.go
@@ -5,7 +5,7 @@
 package model
 
 //Created By BootstrapRulesTemplate.txt found under go/resources folder
-//Created @ 2020-11-20 18:04:48.060615841 +0000 UTC m=+0.040621472
+//Created @ 2020-12-11 16:46:37.129672043 +0000 UTC m=+0.036198532
 
 func BootstrapRules() []Rule {
     var BootstrapRules = []Rule{

--- a/go/model/Criteria.go
+++ b/go/model/Criteria.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/Finding.go
+++ b/go/model/Finding.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/FindingRecipe.go
+++ b/go/model/FindingRecipe.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/FindingTag.go
+++ b/go/model/FindingTag.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/Pattern.go
+++ b/go/model/Pattern.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/Recipe.go
+++ b/go/model/Recipe.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/ReportData.go
+++ b/go/model/ReportData.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/ReportHeader.go
+++ b/go/model/ReportHeader.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/ReportRef.go
+++ b/go/model/ReportRef.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/Rule.go
+++ b/go/model/Rule.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/RuleMetric.go
+++ b/go/model/RuleMetric.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/Run.go
+++ b/go/model/Run.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/RunConfig.go
+++ b/go/model/RunConfig.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/RunConfig_test.go
+++ b/go/model/RunConfig_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/RunSloc.go
+++ b/go/model/RunSloc.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/Scoring.go
+++ b/go/model/Scoring.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/ScoringModel.go
+++ b/go/model/ScoringModel.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/ScoringModelBootstrap.go
+++ b/go/model/ScoringModelBootstrap.go
@@ -5,7 +5,7 @@
 package model
 
 //Created By BootstrapScoringModelsTemplate.txt found under go/resources folder
-//Created @ 2020-11-20 18:04:48.115378652 +0000 UTC m=+0.095384253
+//Created @ 2020-12-11 16:46:37.169680444 +0000 UTC m=+0.076207042
 
 func BootstrapModels() []ScoringModel {
     var BootstrapModels = []ScoringModel{

--- a/go/model/Tag.go
+++ b/go/model/Tag.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/application.go
+++ b/go/model/application.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/constants.go
+++ b/go/model/constants.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/data.go
+++ b/go/model/data.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/pattern_test.go
+++ b/go/model/pattern_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/rule_test.go
+++ b/go/model/rule_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/scoringmodel_test.go
+++ b/go/model/scoringmodel_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/model/sloc.go
+++ b/go/model/sloc.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/natural/EnglishDictionary.go
+++ b/go/natural/EnglishDictionary.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/natural/JavaDictionary.go
+++ b/go/natural/JavaDictionary.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/natural/JavaNaturalLangProcessor.go
+++ b/go/natural/JavaNaturalLangProcessor.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/report/GitReport.go
+++ b/go/report/GitReport.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/report/reports.go
+++ b/go/report/reports.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/scripts/generate_bootstrap.go
+++ b/go/scripts/generate_bootstrap.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  ******************************************************************************/
 
 package main

--- a/go/search/Find.go
+++ b/go/search/Find.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/search/Index.go
+++ b/go/search/Index.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/search/SearchCmd.go
+++ b/go/search/SearchCmd.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/Activity.go
+++ b/go/util/Activity.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/Errors.go
+++ b/go/util/Errors.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/FileIO.go
+++ b/go/util/FileIO.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/Files.go
+++ b/go/util/Files.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/Logging.go
+++ b/go/util/Logging.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/Shared.go
+++ b/go/util/Shared.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/Sorts.go
+++ b/go/util/Sorts.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/Unique.go
+++ b/go/util/Unique.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/buffer.go
+++ b/go/util/buffer.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/comments.go
+++ b/go/util/comments.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/comments_test.go
+++ b/go/util/comments_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/concurrency.go
+++ b/go/util/concurrency.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/language.go
+++ b/go/util/language.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/math.go
+++ b/go/util/math.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/math_test.go
+++ b/go/util/math_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/option.go
+++ b/go/util/option.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/go/util/string.go
+++ b/go/util/string.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 - Present VMWare, Inc. All Rights Reserved.
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
  * SPDX-License-Identifier: BSD-2
  ******************************************************************************/
 

--- a/misc/bin/csv2rule.awk
+++ b/misc/bin/csv2rule.awk
@@ -8,7 +8,7 @@
 BEGIN {
    filename = ""
    yamlFile = ""
-   print "VMWare, copyright 2018. All rights reserved"
+   print "VMware, copyright 2018. All rights reserved"
    FS=","
 }
 

--- a/python/ruler.py
+++ b/python/ruler.py
@@ -10,7 +10,7 @@
 #  REQUIREMENTS:  ---
 #          BUGS:  ---
 #        AUTHOR:  App Tx Team (Steve Woods)
-#       COMPANY:  VMWare
+#       COMPANY:  VMware
 #       VERSION:  1.0
 #       CREATED:  08/16/2020
 #      REVISION:  1.1


### PR DESCRIPTION
Why: VMware was spelled VMWare

What: Logo, trademark.

How: (list of changes):
Signed-off-by: Steve Woods <swoods@vmware.com>