### PR TITLE
Exclude pattern feature

### DIFF
--- a/csa-app/csa/FileProccesor.go
+++ b/csa-app/csa/FileProccesor.go
@@ -353,7 +353,7 @@ func (csaService *CsaService) processPatterns(run *model.Run, app *model.Applica
 					target = regexp.MustCompile(`\r?\n`).ReplaceAllString(result, " ")
 				}
 				// Lets check if the result is valid
-				exclude := csaService.shouldResultBeExcluded(target, rule)
+				exclude := csaService.shouldFindingBeExcluded(target, rule)
 
 				if exclude == false {
 				   csaService.handleRuleMatched(run, app, file, line, target, rule, rule.Patterns[i], output, result, nil)
@@ -363,7 +363,7 @@ func (csaService *CsaService) processPatterns(run *model.Run, app *model.Applica
 				
 			} else if !ok && rule.Negative {
                 // Lets check if the result is valid
-				exclude := csaService.shouldResultBeExcluded(target, rule)
+				exclude := csaService.shouldFindingBeExcluded(target, rule)
 				if exclude == false {
 				    csaService.handleRuleMatched(run, app, file, 0, target, rule, rule.Patterns[i], output, "", nil)
 					findings++
@@ -384,7 +384,7 @@ func (csaService *CsaService) processPatterns(run *model.Run, app *model.Applica
 	return findings
 }
 
-func (csaService *CsaService) shouldResultBeExcluded(target string, rule model.Rule) (exclude bool){
+func (csaService *CsaService) shouldFindingBeExcluded(target string, rule model.Rule) (exclude bool){
 	exclude = false
 	if rule.Excludepatterns != nil {
 		for j := range rule.Excludepatterns {

--- a/csa-app/csa/FileProccesor.go
+++ b/csa-app/csa/FileProccesor.go
@@ -391,8 +391,10 @@ func (csaService *CsaService) shouldFindingBeExcluded(target string, rule model.
 			regex := regexp.MustCompile(rule.Excludepatterns[j].Value)
 			findingExclude := regex.MatchString(target)
 			if findingExclude == true {
-				fmt.Println("Finding by rule "+rule.Name+" excluded by ExcludePattern => " + target)
-				exclude = true
+				if *util.Verbose {
+					fmt.Println("Finding by rule "+rule.Name+" excluded by ExcludePattern => " + target)
+					exclude = true
+				}
 			}
 		}
 	}

--- a/csa-app/db/DbMain.go
+++ b/csa-app/db/DbMain.go
@@ -165,11 +165,12 @@ func checkAndCreateDBDir() {
 }
 
 func createSchema(database *gorm.DB) error {
+	
 	//Create Run
 	db := database.AutoMigrate(model.Run{}, model.ReportRef{}, model.ReportHeader{}, model.ReportData{}, model.Rule{},
 		model.Recipe{}, &model.Pattern{}, model.Tag{}, model.Finding{}, model.FindingTag{}, model.FindingRecipe{},
 		model.RunSloc{}, model.RuleMetric{}, model.Application{}, model.ApplicationTag{}, model.Bin{}, model.BinTag{},
-		model.ScoringModel{})
+		model.ScoringModel{},model.ExcludePattern{})
 
 	return db.Error
 }

--- a/csa-app/db/Rules.go
+++ b/csa-app/db/Rules.go
@@ -158,6 +158,16 @@ func DeleteTags(tags []model.Tag) {
 	}
 }
 
+func DeleteExcludePatterns(excludePatterns []model.ExcludePattern) {
+
+	for _, excludePattern := range excludePatterns {
+		CheckDBError(false,
+			"Import Rules",
+			fmt.Sprintf("Failed Deleting Exclude Pattern [%s]", excludePattern.Value),
+			database.Delete(&excludePattern).Error)
+	}
+}
+
 func getTemplate(templatesDir string, filename string) *template.Template {
 	name := templatesDir + util.PathSeparator + filename
 

--- a/csa-app/db/rule_repository.go
+++ b/csa-app/db/rule_repository.go
@@ -86,7 +86,7 @@ func (ruleRepository *OrmRepository) SaveRule(rule model.Rule) (model.Rule, erro
 
 func (ruleRepository *OrmRepository) GetRuleByName(name string) (model.Rule, error) {
 	var rule model.Rule
-	res := ruleRepository.dbconn.Where(&model.Rule{Name: name}).Preload("Patterns").Preload("Recipes").Preload("Tags").Find(&rule)
+	res := ruleRepository.dbconn.Where(&model.Rule{Name: name}).Preload("Patterns").Preload("Recipes").Preload("Tags").Preload("Excludepatterns").Find(&rule)
 	return rule, res.Error
 }
 
@@ -365,10 +365,11 @@ func (ruleRepository *OrmRepository) unMarshalAndSaveRule(decoder util.FileDecod
 				if *util.Verbose {
 					fmt.Printf("Rule [%s] exists! Updating!", rule.Name)
 				}
-				deletedPatterns, deletedRecipes, deletedTags := existingRule.UpdateRule(rule)
+				deletedPatterns, deletedRecipes, deletedTags, deletedExcludePatterns := existingRule.UpdateRule(rule)
 				DeletePatterns(deletedPatterns)
 				DeleteRecipes(deletedRecipes)
 				DeleteTags(deletedTags)
+				DeleteExcludePatterns(deletedExcludePatterns)
 				ruleRepository.SaveRule(existingRule)
 			} else {
 				if *util.Verbose {

--- a/csa-app/db/rule_repository.go
+++ b/csa-app/db/rule_repository.go
@@ -54,7 +54,7 @@ func NewRuleRepositoryForRun(run *model.Run) RuleRepository {
 
 func (ruleRepository *OrmRepository) GetRules() ([]model.Rule, error) {
 	var rules []model.Rule
-	resp := ruleRepository.dbconn.Preload("Patterns").Preload("Recipes").Preload("Tags").Find(&rules)
+	resp := ruleRepository.dbconn.Preload("Patterns").Preload("Recipes").Preload("Tags").Preload("Excludepatterns").Find(&rules)
 	return rules, resp.Error
 }
 
@@ -303,7 +303,7 @@ func (ruleRepository *OrmRepository) LoadRules() {
 		if len(rules) < 1 {
 			fmt.Printf("Loading rules from Bootstap...\n")
 			cnt := 0
-			for _, rule := range model.BootstrapRules() {
+			for _, rule := range model.BootstrapRules() {			
 				_, err := ruleRepository.SaveRule(rule)
 				if err != nil {
 					util.App.Fatalf("Error saving rule [%s]! Details: %s", rule.Name, err.Error())

--- a/csa-app/model/ExcludePattern.go
+++ b/csa-app/model/ExcludePattern.go
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2018 - Present VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ ******************************************************************************/
+
+package model
+
+import "time"
+
+type ExcludePattern struct {
+	ID        uint      `gorm:"primary_key" json:"-" yaml:"-"`
+	CreatedAt time.Time `json:"-" yaml:"-"`
+	UpdatedAt time.Time `json:"-" yaml:"-"`
+	RuleID    uint      `sql:"type:bigint REFERENCES rules(id) ON DELETE CASCADE" json:"-"  yaml:"-"`
+	Rule      Rule      `gorm:"foreignkey:RuleID" json:"-"  yaml:"-"`
+	Value     string    `gorm:"type:text"`
+}

--- a/csa-app/model/Rule.go
+++ b/csa-app/model/Rule.go
@@ -34,6 +34,7 @@ type Rule struct {
 	Tags            []Tag          `json:",omitempty" yaml:",omitempty"`
 	Recipes         []Recipe       `gorm:"foreignkey:RuleID" json:",omitempty" yaml:",omitempty"`
 	Patterns        []Pattern      `gorm:"foreignkey:RuleID"`
+	Excludepatterns []ExcludePattern      `gorm:"foreignkey:RuleID" json:",omitempty" yaml:",omitempty"`
 	fileNameRegex   *regexp.Regexp `gorm:"-" json:"-" yaml:"-"`
 	regex           *regexp.Regexp `gorm:"-" json:"-" yaml:"-"`
 	Metric          *RuleMetric    `gorm:"-" json:"-" yaml:"-"`

--- a/csa-app/resources/BootstrapRulesTemplate.txt
+++ b/csa-app/resources/BootstrapRulesTemplate.txt
@@ -13,6 +13,8 @@ func BootstrapRules() []Rule {
             { Name: "{{.Name}}", FileType: "{{.FileType}}", Target: "{{.Target}}", Type: "{{.Type}}", DefaultPattern: "{{.GetEscapedPattern}}", Advice: "{{.Advice}}", Effort: {{.Effort}}, Readiness: {{.Readiness}}, Impact: "{{.Impact}}", Category: "{{.Category}}", Criticality: "{{.Criticality}}",
             Tags:
             []Tag{ {{ range .Tags }} { Value: "{{.Value}}",},{{end}} },
+            Excludepatterns:
+            []ExcludePattern{ {{ range .Excludepatterns }} { Value: "{{.Value}}",},{{end}} },
             Recipes:
             []Recipe{ {{ range .Recipes }} { URI: "{{.URI}}", }, {{end}} },
             Patterns:


### PR DESCRIPTION
It is very difficult to deal with **false positives**. Unfortunately GO does not have support for **lookahead** and **lookbehind** that could allow regexes to exclude findings if they are preceded or end with a particular string.

This is a proposal that would allow rules to define **Excludepatterns** that would provide a way to invalidate findings and they match within a set of exclude regex patterns. 

For example bellow this set of exclude patterns would help with avoiding false positives when looking for hard coded IPs.
For .Net these false positives represent 98% of the findings for this rule.

Rule: dotnet-ipv4-addresses

excludepatterns:
- value: .GeneratedCodeAttribute\(.*[,]
- value: AssemblyFileVersion\(
- value: AssemblyVersion\(
- value: Version=
- value: '"assemblyVersion".*[:].".*"'
- value: '"fileVersion".*[:].".*"'
- value: PackageReference.*Version="
- value: GeneratedCode\(
- value: ([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))  // Remove dates formatted that could be interpreted as IPs
