### PR TITLE
Rule Profiles

### DIFF
--- a/csa-app/csa/FileProccesor.go
+++ b/csa-app/csa/FileProccesor.go
@@ -628,7 +628,7 @@ func (csaService *CsaService) getRules(run *model.Run, config *model.Application
 	//If Profiles for rules are selected, it takes precedence over Include and Exclude Tags
 	if config.Profiles != "" {
 		fmt.Printf("Using only rules with profiles [%s]\n", config.Profiles)
-		return csaService.ruleRepository.GetRulesForRunRestrictedByProfiles(run, strings.Split(config.Profiles, ","), false)
+		return csaService.ruleRepository.GetRulesForRunRestrictedByProfiles(run, strings.Split(config.Profiles, ","))
 	} else {
 		if config.RuleIncludeTags != "" {
 			fmt.Printf("Using only rules with tags [%s]\n", config.RuleIncludeTags)

--- a/csa-app/csa/FileProccesor.go
+++ b/csa-app/csa/FileProccesor.go
@@ -424,13 +424,20 @@ func (csaService *CsaService) generateSloc(run *model.Run) {
 
 func (csaService *CsaService) getRules(run *model.Run, config *model.ApplicationConfig) (rules []model.Rule, err error) {
 	//Include overrules anything
-	if config.RuleIncludeTags != "" {
-		fmt.Printf("Using only rules with tags [%s]\n", config.RuleIncludeTags)
-		return csaService.ruleRepository.GetRulesForRunRestricted(run, strings.Split(config.RuleIncludeTags, ","), false)
-	} else if config.RuleExcludeTags != "" {
-		fmt.Printf("Using only rules without tags [%s]\n", config.RuleExcludeTags)
-		return csaService.ruleRepository.GetRulesForRunRestricted(run, strings.Split(config.RuleExcludeTags, ","), true)
+	//If Profiles for rules are selected, it takes precedence over Include and Exclude Tags
+	if config.Profiles != "" {
+		fmt.Printf("Using only rules with profiles [%s]\n", config.Profiles)
+		return csaService.ruleRepository.GetRulesForRunRestrictedByProfiles(run, strings.Split(config.Profiles, ","), false)
+	} else {
+		if config.RuleIncludeTags != "" {
+			fmt.Printf("Using only rules with tags [%s]\n", config.RuleIncludeTags)
+			return csaService.ruleRepository.GetRulesForRunRestricted(run, strings.Split(config.RuleIncludeTags, ","), false)
+		} else if config.RuleExcludeTags != "" {
+			fmt.Printf("Using only rules without tags [%s]\n", config.RuleExcludeTags)
+			return csaService.ruleRepository.GetRulesForRunRestricted(run, strings.Split(config.RuleExcludeTags, ","), true)
+		}
 	}
+	
 	return csaService.ruleRepository.GetRulesForRun(run)
 }
 

--- a/csa-app/db/DbMain.go
+++ b/csa-app/db/DbMain.go
@@ -169,7 +169,7 @@ func createSchema(database *gorm.DB) error {
 	db := database.AutoMigrate(model.Run{}, model.ReportRef{}, model.ReportHeader{}, model.ReportData{}, model.Rule{},
 		model.Recipe{}, &model.Pattern{}, model.Tag{}, model.Finding{}, model.FindingTag{}, model.FindingRecipe{},
 		model.RunSloc{}, model.RuleMetric{}, model.Application{}, model.ApplicationTag{}, model.Bin{}, model.BinTag{},
-		model.ScoringModel{})
+		model.ScoringModel{},model.Profile{})
 
 	return db.Error
 }

--- a/csa-app/db/Rules.go
+++ b/csa-app/db/Rules.go
@@ -158,6 +158,16 @@ func DeleteTags(tags []model.Tag) {
 	}
 }
 
+func DeleteProfiles(profiles []model.Profile) {
+
+	for _, profile := range profiles {
+		CheckDBError(false,
+			"Import Rules",
+			fmt.Sprintf("Failed Deleting Profile [%s]", profile.Value),
+			database.Delete(&profile).Error)
+	}
+}
+
 func getTemplate(templatesDir string, filename string) *template.Template {
 	name := templatesDir + util.PathSeparator + filename
 

--- a/csa-app/db/rule_repository.go
+++ b/csa-app/db/rule_repository.go
@@ -29,7 +29,7 @@ type RuleRepository interface {
 	GetRules() ([]model.Rule, error)
 	GetRulesForRun(run *model.Run) ([]model.Rule, error)
 	GetRulesForRunRestricted(run *model.Run, tags []string, excluded bool) ([]model.Rule, error)
-	GetRulesForRunRestrictedByProfiles(run *model.Run, tags []string, excluded bool) ([]model.Rule, error)
+	GetRulesForRunRestrictedByProfiles(run *model.Run, profiles []string) ([]model.Rule, error)
 	ExportRules()
 	ImportRules()
 	LoadRules()
@@ -104,35 +104,20 @@ func (ruleRepository *OrmRepository) GetRulesForRun(run *model.Run) ([]model.Rul
 	return rules, nil
 }
 
-func (ruleRepository *OrmRepository) GetRulesForRunRestrictedByProfiles(run *model.Run, tags []string, excluded bool) ([]model.Rule, error) {
+func (ruleRepository *OrmRepository) GetRulesForRunRestrictedByProfiles(run *model.Run, profiles []string) ([]model.Rule, error) {
 	rules, err := ruleRepository.GetRules()
 	var restrictedRules []model.Rule
 	if err != nil {
 		return nil, err
 	}
 
-	if len(tags) > 0 {
-		if excluded {
-			for i := range rules {
-				shouldAdd := true
-				for _, tag := range tags {
-					//Have to check against every tag!
-					if rules[i].HasProfile(tag) {
-						shouldAdd = false
-					}
-				}
-				if shouldAdd {
+	if len(profiles) > 0 {
+		for i := range rules {
+			for _, profile := range profiles {
+				if rules[i].HasProfile(profile) {
 					restrictedRules = append(restrictedRules, rules[i])
-				}
-			}
-		} else {
-			for i := range rules {
-				for _, tag := range tags {
-					if rules[i].HasProfile(tag) {
-						restrictedRules = append(restrictedRules, rules[i])
-						//Only add rule for first rule once
-						break
-					}
+					//Only add rule for first rule once
+					break
 				}
 			}
 		}

--- a/csa-app/model/ApplicationConfig.go
+++ b/csa-app/model/ApplicationConfig.go
@@ -35,6 +35,7 @@ type ApplicationConfig struct {
 	Files            []*util.FileInfo `json:"-" yaml:"-"`
 	IgnoredFiles     []*util.FileInfo `json:"-" yaml:"-"`
 	FileUtil         *util.FileUtil   `json:"-" yaml:"-"`
+	Profiles  string                  `json:"profiles,omitempty" yaml:"profiles,omitempty"`
 }
 
 type configFileConfig struct {
@@ -49,6 +50,7 @@ type configFileConfig struct {
 	DirExcludeRegex  string  `json:"dir-exclude-regex" yaml:"dir-exclude-regex"`
 	IncludeFileRegex string  `json:"include-file-regex" yaml:"include-file-regex"`
 	ExcludeFileRegex string  `json:"exclude-file-regex" yaml:"exclude-file-regex"`
+	Profiles  string         `json:"profiles" yaml:"profiles"`
 }
 
 func NewApplicationConfig(runConfig *RunConfig) *ApplicationConfig {
@@ -141,6 +143,10 @@ func (c *ApplicationConfig) MergeRunConfig(runConfig *RunConfig) {
 			c.RuleIncludeTags = ac.RuleIncludeTags
 		}
 
+		if c.Profiles == "" {
+			c.Profiles = ac.Profiles
+		}
+
 		if c.RuleExcludeTags == "" {
 			c.RuleExcludeTags = ac.RuleExcludeTags
 		}
@@ -165,6 +171,10 @@ func (c *ApplicationConfig) MergeRunConfig(runConfig *RunConfig) {
 	//Check for any empty and override from base config
 	if c.RuleIncludeTags == "" {
 		c.RuleIncludeTags = runConfig.RuleIncludeTags
+	}
+
+	if c.Profiles == "" {
+		c.Profiles = runConfig.Profiles
 	}
 
 	if c.RuleExcludeTags == "" {
@@ -195,6 +205,10 @@ func (c *ApplicationConfig) Merge(mergeConfig *configFileConfig) {
 
 	if util.IsCmdFlagDefaulted(util.ANALYZE_CMD, util.RULE_INCLUDE_FLAG) && mergeConfig.RuleIncludeTags != "" {
 		c.RuleIncludeTags = mergeConfig.RuleIncludeTags
+	}
+
+	if util.IsCmdFlagDefaulted(util.ANALYZE_CMD, util.PROFILE_FLAG) && mergeConfig.Profiles != "" {
+		c.Profiles = mergeConfig.Profiles
 	}
 
 	if util.IsCmdFlagDefaulted(util.ANALYZE_CMD, util.RULE_EXCLUDE_FLAG) && mergeConfig.RuleExcludeTags != "" {
@@ -305,7 +319,7 @@ func (c *ApplicationConfig) CheckForLocalAppConfig() {
 			c.BusinessValue, c.ScoringModel,
 			c.RuleIncludeTags, c.RuleExcludeTags,
 			c.DirExcludeRegex, c.IncludeFileRegex,
-			c.ExcludeFileRegex}
+			c.ExcludeFileRegex, c.Profiles}
 
 		format := util.YAML
 		if *util.OutputFormatJson {

--- a/csa-app/model/Profile.go
+++ b/csa-app/model/Profile.go
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2023 - Present VMware, Inc. All Rights Reserved.
+ * SPDX-License-Identifier: BSD-2
+ ******************************************************************************/
+
+package model
+
+import "time"
+
+type Profile struct {
+	ID        uint      `gorm:"primary_key" json:"-" yaml:"-"`
+	CreatedAt time.Time `json:"-" yaml:"-"`
+	UpdatedAt time.Time `json:"-" yaml:"-"`
+	RuleID    uint      `sql:"type:bigint REFERENCES rules(id) ON DELETE CASCADE" json:"-"  yaml:"-"`
+	Rule      Rule      `gorm:"foreignkey:RuleID" json:"-"  yaml:"-"`
+	Value     string    `gorm:"type:text"`
+}

--- a/csa-app/model/Rule.go
+++ b/csa-app/model/Rule.go
@@ -164,11 +164,11 @@ func (r *Rule) HasTag(tag string) bool {
 	return false
 }
 
-func (r *Rule) HasProfile(tag string) bool {
-	if tag != "" && len(r.Profiles) > 0 {
+func (r *Rule) HasProfile(profile string) bool {
+	if profile != "" && len(r.Profiles) > 0 {
 		for i := range r.Profiles {
 			//Case insensitive matching!
-			if strings.ToLower(tag) == strings.ToLower(r.Profiles[i].Value) {
+			if strings.ToLower(profile) == strings.ToLower(r.Profiles[i].Value) {
 				return true
 			}
 		}

--- a/csa-app/model/RunConfig.go
+++ b/csa-app/model/RunConfig.go
@@ -31,6 +31,7 @@ type RunConfig struct {
 	IncludeFileRegex string               `json:"include-file-regex" yaml:"include-file-regex"`
 	ExcludeFileRegex string               `json:"exclude-file-regex" yaml:"exclude-file-regex"`
 	FileUtil         *util.FileUtil       `json:"-" yaml:"-"`
+	Profiles  string                      `json:"profiles" yaml:"profiles"`
 }
 
 func NewRunConfig(run *Run, fileUtil *util.FileUtil) *RunConfig {
@@ -45,6 +46,7 @@ func NewRunConfig(run *Run, fileUtil *util.FileUtil) *RunConfig {
 		*util.IncludedFilesRegEx,
 		*util.ExcludedFilesRegEx,
 		fileUtil,
+		*util.Profiles,
 	}
 }
 

--- a/csa-app/resources/BootstrapRulesTemplate.txt
+++ b/csa-app/resources/BootstrapRulesTemplate.txt
@@ -13,6 +13,8 @@ func BootstrapRules() []Rule {
             { Name: "{{.Name}}", FileType: "{{.FileType}}", Target: "{{.Target}}", Type: "{{.Type}}", DefaultPattern: "{{.GetEscapedPattern}}", Advice: "{{.Advice}}", Effort: {{.Effort}}, Readiness: {{.Readiness}}, Impact: "{{.Impact}}", Category: "{{.Category}}", Criticality: "{{.Criticality}}",
             Tags:
             []Tag{ {{ range .Tags }} { Value: "{{.Value}}",},{{end}} },
+            Profiles:
+            []Profile{ {{ range .Profiles }} { Value: "{{.Value}}",},{{end}} },
             Recipes:
             []Recipe{ {{ range .Recipes }} { URI: "{{.URI}}", }, {{end}} },
             Patterns:

--- a/csa-app/util/Shared.go
+++ b/csa-app/util/Shared.go
@@ -30,6 +30,7 @@ var (
 	DBDriverFlags     = App.Flag("db-driver-flags", "flags to configure the database driver (Default: sqlite: "+Sqlite_driverFlags+" postgres: "+Postgres_driverFlags).String()
 	ReportsFlag       = App.Flag("report", "comma delimited list of report(s) to run. (for example \"-r1,3,4\". 0=All)").Default("0").Short('r').String()
 	TmpDirPath        = App.Flag("temp-dir", "The root path where files created by csa will be placed. Defaults to OS specific temp path/run-id").Short('t').String()
+	
 
 	//Get Build Info
 	BuildInfoCmd = App.Command("info", "Get full build details of this csa executable")
@@ -75,7 +76,7 @@ var (
 	ScoringModel          = AnalyzeCmd.Flag(SCORING_MODEL_FLAG, "the name of the scoring model to use for scoring applications").Short('s').Default("default").String()
 	MaxProcs              = AnalyzeCmd.Flag("max-procs", "Set the max concurrency from a processor perspective. Defaults to system processor count.").Int()
 	MaxThreads            = AnalyzeCmd.Flag("max-threads", "Set the max OS threads that csa can utilize. Default is '20000'").Default(strconv.Itoa(20000)).Int()
-
+	Profiles              = AnalyzeCmd.Flag("profiles", "The list of rule profiles that will be selected for the scan. Multiple profiles can separated by commas.").String()
 	//Search Command
 	SearchCmd = App.Command("search", "search full text index for findings based on query")
 
@@ -188,6 +189,7 @@ const DEFAULT_MAX_POSTGRES_WORKERS = 10
 
 //CMDS
 const ANALYZE_CMD string = "analyze"
+const PROFILE_FLAG string = "profiles"
 const RULE_INCLUDE_FLAG string = "rule-include-tags"
 const RULE_EXCLUDE_FLAG string = "rule-exclude-tags"
 const EXCLUDED_DIRS_FLAG string = "excluded-dirs"


### PR DESCRIPTION
This feature provides a way to only pick up rules for specific profiles. Profiles could be: Cloud Suitability, .NetCore Portability, Migration to TAS...A rule can have also multiple profiles.
```
profiles: 
  - value: cloud-suitability
 ```
or 
```
profiles: 
  - value: net-core
```
When CSA is run with a profile selection, only the rules meeting that profile requirement will be picked up and used for the scan
```
**./csa --profiles=cloud-suitability,net-core** 
```