### PR TITLE
Adding arm64 build for linux

### DIFF
--- a/csa-app/.goreleaser.yaml
+++ b/csa-app/.goreleaser.yaml
@@ -115,6 +115,7 @@ builds:
 
     goarch:
       - amd64
+      - arm64
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
This allows to run CSA in a Linux container on an ARM-based hardware.